### PR TITLE
Add basic process list refreshing capability

### DIFF
--- a/ManagedInjector.GUI/UI/MainWindow/MainWindow.xaml
+++ b/ManagedInjector.GUI/UI/MainWindow/MainWindow.xaml
@@ -63,6 +63,7 @@
                 </GroupBox>
                 <!-- TODO: button to refresh processes -->
                 <Button IsEnabled="{Binding InjectButtonEnabled, Mode=OneWay}" Command="{Binding InjectCommand, Mode=OneTime}">Inject</Button>
+                <Button IsEnabled="true" Command="{Binding RefreshProcCommand, Mode=OneWay}">Refresh Processlist</Button>
             </StackPanel>
 
             <Grid DockPanel.Dock="Bottom" VerticalAlignment="Bottom">

--- a/ManagedInjector.GUI/UI/MainWindow/MainWindowVM.cs
+++ b/ManagedInjector.GUI/UI/MainWindow/MainWindowVM.cs
@@ -30,6 +30,7 @@ namespace ManagedInjector.GUI.UI.MainWindow
 			_window = window;
 			SelectAssemblyCommand = new ActionCommand(SelectAssembly);
 			InjectCommand = new ActionCommand(Inject);
+			RefreshProcCommand = new ActionCommand(RefreshProcesses);
 			AboutCommand = new ActionCommand(About);
 
 			// TODO: should be done in the background. currently blocks UI thread during startup and could throw
@@ -58,6 +59,7 @@ namespace ManagedInjector.GUI.UI.MainWindow
 		public ICommand SelectAssemblyCommand { get; }
 		public ICommand InjectCommand { get; }
 		public ICommand AboutCommand { get; }
+		public ICommand RefreshProcCommand { get; }
 
 		public IReadOnlyList<UserProcess> Processes
 		{


### PR DESCRIPTION
Hey bro,

I used this jit a while back like 9 mos ago because I was lazy and didnt want to write a .NET injector for something I was testing.  I forget for what exactly but doesnt matter. One thing I know was that whatever I was testing would crash and I would need to re-launch the process and find the new process to inject. That involved exiting and re-opening the app. I saw it was a xaml app and was super duper clean prof C# (thanks btw) and said id try to add a refresh button one day.

Day was today. I've implemented it here. Super basic. I wanted to make it do a slight gray-out delay when it's clicked but my .NET GUI knowledge is limited to GTKMono for real and hella long ago....and i failed. So just added a non-fancy basic process list refresh button.

Thanks again homie.